### PR TITLE
Add works with dotenv-vault badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![dotenv-vault](https://badge.dotenv.org/works-with.svg?r=1)](https://www.dotenv.org/r/github.com/dotenv-org/dotenv-vault?r=1)
+
 # React Firebase Auth starter app with PWA using Workbox
 
 


### PR DESCRIPTION
Hi 👋 @marshyon,

I think it's really cool you are using dotenv-vault with an open source project. It will always be free for this (and for teams under 4 people).

I thought you'd like to maybe show that off so here is a badge for your project.

P.S. If you have ideas for how dotenv-vault can work better for open source projects, let me know. I'm all ears.